### PR TITLE
Add tensorflow-inception pipeline for image recognition

### DIFF
--- a/incubator/tensorflow-inception/README.md
+++ b/incubator/tensorflow-inception/README.md
@@ -1,0 +1,85 @@
+# TensorFlow Inception Example
+
+## Introduction
+
+This example uses the Minio S3 clone to show case a kubeless pubsub function.
+Minio is configured to send notifications to Kafka, a function consumes those events and performs actions.
+
+The Minio access keys are stored as a Kubernetes secret
+
+### 1. Install kubeless on your kubernetes cluster
+
+```bash
+$ kubeless install
+```
+
+### 2. Deploy TensorFlow Inception via Helm
+
+From this folder:
+
+```bash
+$ helm install --name tensorflow-inception ./charts/tensorflow-inception --set serviceType=NodePort
+```
+
+> NOTE: It can take a couple of minutes to the tensorflow deployment to be in running state as it need to run a Jon to populate the training data.
+
+### 3. Deploy Minio via Helm
+
+If you have cloned the kubeless repo:
+
+```bash
+$ helm install --name minio ./charts/minio --set serviceType=NodePort
+```
+
+This will use the default values in `./charts/minio/values.yaml`
+
+Check the logs of the Minio pod for configuration info.
+
+### 4. Configure Minio
+
+You will need the [Minio client](https://github.com/minio/mc) `mc`:
+
+```bash
+$ brew install minio-mc
+```
+
+The following are Minio specific, it assumes your are using minikube on `192.168.99.100`
+
+```bash
+$ mc config host add localminio http://192.168.99.100:32751 foobar foobarfoo
+```
+
+Create the bucket:
+
+```bash
+$ mc mb localminio/images
+```
+
+Turn on events for a `images` bucket:
+
+```bash
+$ mc events add localminio/images arn:minio:sqs:us-east-1:1:kafka --events put
+```
+
+Check bucket
+
+```bash
+$ mc ls localminio/images
+```
+
+### 5. Create kubernetes secret for slack token
+
+In order to access to Slack we need the token to be available from the kubeless function. To keep it secure we will use kubernetes secrets to store this info and we will retrieve it from the function itself.
+
+```bash
+$ kubectl create secret generic slack-token --from-literal=token=YOUR_SLACK_TOKEN
+```
+
+We also need the `access_key` and `secret_key` in order to access to the Minio server but a kubernetes secret containing this values was already created installing the helm chart.
+
+
+### 6. Deploy minio-tf-slack-bot function
+
+```bash
+kubeless function deploy minio-tf-slack-bot --trigger-topic s3 --from-file bot.py --handler bot.handler --runtime python2.7 --dependencies requirements.txt
+```

--- a/incubator/tensorflow-inception/bot.py
+++ b/incubator/tensorflow-inception/bot.py
@@ -1,0 +1,138 @@
+import time
+import json
+import base64
+import tempfile
+import urllib
+
+# pip install slackclient
+from slackclient import SlackClient
+
+# pip install kubernetes
+from kubernetes import client, config
+from kubernetes.client import configuration
+from kubernetes.client.apis import core_v1_api
+from kubernetes.client.rest import ApiException
+
+# pip install minio
+from minio import Minio
+from minio.error import ResponseError
+
+# load incluster_config
+config.load_incluster_config()
+v1=client.CoreV1Api()
+
+# In order to avoid issue with kubernetes hostnames when using python 2
+configuration.assert_hostname = False
+
+# Get minio and slack secrets
+for secrets in v1.list_secret_for_all_namespaces().items:
+    if secrets.metadata.name == 'minio-minio-user':
+        access_key = base64.b64decode(secrets.data['accesskey'])
+        secret_key = base64.b64decode(secrets.data['secretkey'])
+    if secrets.metadata.name == 'slack-token':
+        slack_token = base64.b64decode(secrets.data['token'])
+
+
+# Replace the DNS below with the minio service name (helm release name -svc)
+client = Minio('minio-minio-svc:9000',
+                  access_key=access_key,
+                  secret_key=secret_key,
+                  secure=False)
+
+# Slack token
+sc = SlackClient(slack_token)
+
+pod_name = 'tensorflow-inception'
+
+# Check if pod already exists
+resp = None
+try:
+    resp = v1.read_namespaced_pod(name=pod_name,
+                                   namespace='default')
+except ApiException as e:
+    if e.status != 404:
+        print("Unknown error: %s" % e)
+        exit(1)
+
+# Create pod if not exists
+if not resp:
+    print("Pod %s does not exits. Creating it..." % pod_name)
+    pod_manifest = {
+        'apiVersion': 'v1',
+        'kind': 'Pod',
+        'metadata': {
+            'name': pod_name
+        },
+        'spec': {
+            'containers': [{
+                'image': 'bitnami/tensorflow-inception',
+                'name': 'tf-inception'
+            }]
+        }
+    }
+    resp = v1.create_namespaced_pod(body=pod_manifest, namespace='default')
+    while True:
+        resp = v1.read_namespaced_pod(name=pod_name, namespace='default')
+        print("resp.status.phase is %s" % resp.status.phase)
+        if resp.status.phase != 'Pending':
+            print("resp.status.phase is not Pending...exiting")
+            break
+        time.sleep(1)
+    print("Pod %s successfully created" % pod_name)
+
+    # Install minio client in tensorflow-inception pod to retrieve the image
+    exec_command = ['/bin/sh',
+                    '-c',
+                    'curl -JLO https://dl.minio.io/client/mc/release/linux-amd64/mc && \
+                    chmod a+x mc && \
+                    ./mc config host add remoteminio http://minio-minio-svc:9000 %s %s' % (access_key, secret_key)]
+
+    # Exec command in container and retrieve response
+    resp = v1.connect_get_namespaced_pod_exec(pod_name, 'default', command=exec_command, stderr=True, stdin=False, stdout=True, tty=False)
+    print("Minio client installed in %s pod. Output: %s" % pod_name, resp)
+
+print("Pod ready to accept commands")
+
+
+def handler(context):
+
+    if context['EventType'] == "s3:ObjectCreated:Put":
+
+        tf = tempfile.NamedTemporaryFile(delete=False)
+        bucket = context['Key'].split('/')[0]
+        filename = context['Key'].split('/')[1]
+
+        # Fetching source file from Minio to send it to slack
+        try:
+            print 'Fetching file'
+            client.fget_object(bucket, filename, tf.name)
+        except ResponseError as err:
+            print 'Error fetching file'
+            print err
+
+        # Retrieve image from minio and send to tensorflow-serving
+        exec_command = ['/bin/sh',
+                        '-c',
+                        './mc cp remoteminio/images/' + filename + ' . > /dev/null 2>&1 && \
+                        inception_client --server=tensorflow-inception-tensorflow-serving:9000 --image=' + filename]
+
+        # Exec command in container and retrieve response
+        resp = v1.connect_get_namespaced_pod_exec(pod_name, 'default', command=exec_command, stderr=True, stdin=False, stdout=True, tty=False)
+
+        print("Response: " + resp)
+
+
+        msg = "New image uploaded to Minio and categorized by TensorFlow Inception"
+        attachments = """[{"fallback": "New image upload to Minio and categorized by TensorFlow Inception",
+                         "pretext": "The above image called %s was uploaded to bucket %s",
+                         "title": '%s',
+                         "text": '%s',
+                         "color": "#7CD197"}]""" % (filename, bucket, filename, resp)
+
+        # Send image and tensorflow-inception output to slack
+        sc.api_call("files.upload", filename=filename, channels='#bots-tests', file=open(tf.name, 'rb'))
+        sc.api_call("chat.postMessage", channel="#bots-tests", text=msg, attachments=attachments)
+
+
+
+    return "Image and tensorflow-inception output sent to SLACK"

--- a/incubator/tensorflow-inception/charts/minio/.helmignore
+++ b/incubator/tensorflow-inception/charts/minio/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/incubator/tensorflow-inception/charts/minio/Chart.yaml
+++ b/incubator/tensorflow-inception/charts/minio/Chart.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+description: Distributed object storage server built for cloud applications and devops.
+name: minio
+version: 0.1.0
+keywords:
+- storage
+- object-storage
+- S3
+home: https://minio.io
+icon: https://www.minio.io/logo/img/logo-dark.svg
+sources:
+- https://github.com/minio/minio
+maintainers:
+- name: Acaleph
+  email: hello@acale.ph
+- name: Minio
+  email: hello@minio.io

--- a/incubator/tensorflow-inception/charts/minio/README.md
+++ b/incubator/tensorflow-inception/charts/minio/README.md
@@ -1,0 +1,169 @@
+Minio
+=====
+
+[Minio](https://minio.io) is a lightweight, AWS S3 compatible object storage server. It is best suited for storing unstructured data such as photos, videos, log files, backups, VM and container images. Size of an object can range from a few KBs to a maximum of 5TB. Minio server is light enough to be bundled with the application stack, similar to NodeJS, Redis and MySQL.
+
+Minio supports [distributed mode](https://docs.minio.io/docs/distributed-minio-quickstart-guide). In distributed mode, you can pool multiple drives (even on different machines) into a single object storage server.
+
+Introduction
+------------
+
+This chart bootstraps Minio deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+
+Prerequisites
+-------------
+
+-	Kubernetes 1.4+ with Beta APIs enabled for default standalone mode.
+-   Kubernetes 1.5+ with Beta APIs enabled to run Minio in [distributed mode](#distributed-minio).
+-	PV provisioner support in the underlying infrastructure.
+
+Installing the Chart
+--------------------
+
+Install this chart using:
+
+```bash
+$ helm install stable/minio
+```
+
+The command deploys Minio on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
+
+### Release name
+
+An instance of a chart running in a Kubernetes cluster is called a release. Each release is identified by a unique name within the cluster. Helm automatically assigns a unique release name after installing the chart. You can also set your preferred name by:
+
+```bash
+$ helm install --name my-release stable/minio
+```
+
+### Access and Secret keys
+
+By default a pre-generated access and secret key will be used. To override the default keys, pass the access and secret keys as arguments to helm install.
+
+```bash
+$ helm install --set accessKey=myaccesskey,secretKey=mysecretkey \
+    stable/minio
+```
+### Updating Minio configuration via Helm
+
+[ConfigMap](https://kubernetes.io/docs/user-guide/configmap/) allows injecting containers with configuration data even while a Helm release is deployed.
+
+To update your Minio server configuration while it is deployed in a release, you need to
+
+1. Check all the configurable values in the Minio chart using `helm inspect values stable/minio`.
+2. Override the `minio_server_config` settings in a YAML formatted file, and then pass that file like this `helm upgrade -f config.yaml stable/minio`.
+3. Restart the Minio server(s) for the changes to take effect.
+
+You can also check the history of upgrades to a release using `helm history my-release`. Replace `my-release` with the actual release name.
+
+Uninstalling the Chart
+----------------------
+
+Assuming your release is named as `my-release`, delete it using the command:
+
+```bash
+$ helm delete my-release
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+Configuration
+-------------
+
+The following tables lists the configurable parameters of the Minio chart and their default values.
+
+| Parameter                  | Description                         | Default                                                 |
+|----------------------------|-------------------------------------|---------------------------------------------------------|
+| `image`                    | Minio image name                    | `minio/minio`                                           |
+| `imageTag`                 | Minio image tag. Possible values listed [here](https://hub.docker.com/r/minio/minio/tags/).| `RELEASE.2017-02-16T01-47-30Z`|
+| `imagePullPolicy`          | Image pull policy                   | `Always`                                                |
+| `mode`                     | Minio server mode (`standalone`, `shared` or `distributed`)| `standalone`                     |
+| `replicas`                 | Number of nodes (applicable only for Minio distributed mode). Should be 4 <= x <= 16 | `4`    |
+| `accessKey`                | Default access key                  | `AKIAIOSFODNN7EXAMPLE`                                  |
+| `secretKey`                | Default secret key                  | `wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY`              |
+| `configPath`               | Default config file location        | `~/.minio`                                              |
+| `mountPath`                | Default mount location for persistent drive| `/export`                                        |
+| `serviceType`              | Kubernetes service type             | `LoadBalancer`                                          |
+| `servicePort`              | Kubernetes port where service is exposed| `9000`                                              |
+| `persistence.enabled`      | Use persistent volume to store data | `true`                                                  |
+| `persistence.size`         | Size of persistent volume claim     | `10Gi`                                                  |
+| `persistence.storageClass` | Type of persistent volume claim     | `generic`                                               |
+| `persistence.accessMode`   | ReadWriteOnce or ReadOnly           | `ReadWriteOnce`                                         |
+| `resources`                | CPU/Memory resource requests/limits | Memory: `256Mi`, CPU: `100m`                            |
+
+Some of the parameters above map to the env variables defined in the [Minio DockerHub image](https://hub.docker.com/r/minio/minio/).
+
+You can specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
+
+```bash
+$ helm install --name my-release \
+  --set persistence.size=100Gi \
+    stable/minio
+```
+
+The above command deploys Minio server with a 100Gi backing persistent volume.
+
+Alternately, you can provide a YAML file that specifies parameter values while installing the chart. For example,
+
+```bash
+$ helm install --name my-release -f values.yaml stable/minio
+```
+
+> **Tip**: You can use the default [values.yaml](values.yaml)
+
+Distributed Minio
+-----------
+
+This chart provisions a Minio server in standalone mode, by default. To provision Minio server in [distributed mode](https://docs.minio.io/docs/distributed-minio-quickstart-guide), set the `mode` field to `distributed`,
+
+```bash
+$ helm install --set mode=distributed stable/minio
+```
+
+This provisions Minio server in distributed mode with 4 nodes. To change the number of nodes in your distributed Minio server, set the `replicas` field,
+
+```bash
+$ helm install --set mode=distributed,replicas=8 stable/minio
+```
+
+This provisions Minio server in distributed mode with 8 nodes. Note that the `replicas` value should be an integer between 4 and 16 (inclusive).
+
+### StatefulSet [limitations](http://kubernetes.io/docs/concepts/abstractions/controllers/statefulsets/#limitations) applicable to distributed Minio
+
+1. StatefulSets need persistent storage, so the `persistence.enabled` flag is ignored when `mode` is set to `distributed`.
+2. When uninstalling a distributed Minio release, you'll need to manually delete volumes associated with the StatefulSet.
+
+Shared Minio
+-----------
+
+### Prerequisites
+
+Minio shared mode deployment creates multiple Minio server instances backed by single PV in `ReadWriteMany` mode. Currently few [Kubernetes volume plugins](https://kubernetes.io/docs/user-guide/persistent-volumes/#access-modes) support `ReadWriteMany` mode. To deploy Minio shared mode you'll need to have a Persistent Volume running with one of the supported volume plugins. [This document](https://kubernetes.io/docs/user-guide/volumes/#nfs)
+outlines steps to create a NFS PV in Kubernetes cluster.
+
+### Provision Shared Minio instances
+
+To provision Minio servers in [shared mode](https://github.com/minio/minio/blob/master/docs/shared-backend/README.md), set the `mode` field to `shared`,
+
+```bash
+$ helm install --set mode=shared stable/minio
+```
+
+This provisions 4 Minio server nodes backed by single storage. To change the number of nodes in your shared Minio deployment, set the `replicas` field,
+
+```bash
+$ helm install --set mode=shared,replicas=8 stable/minio
+```
+
+This provisions Minio server in shared mode with 8 nodes.
+
+Persistence
+-----------
+
+This chart provisions a PersistentVolumeClaim and mounts corresponding persistent volume to default location `/export`. You'll need physical storage available in the Kubernetes cluster for this to work. If you'd rather use `emptyDir`, disable PersistentVolumeClaim by:
+
+```bash
+$ helm install --set persistence.enabled=false stable/minio
+```
+
+> *"An emptyDir volume is first created when a Pod is assigned to a Node, and exists as long as that Pod is running on that node. When a Pod is removed from a node for any reason, the data in the emptyDir is deleted forever."*

--- a/incubator/tensorflow-inception/charts/minio/templates/NOTES.txt
+++ b/incubator/tensorflow-inception/charts/minio/templates/NOTES.txt
@@ -1,0 +1,38 @@
+{{- if eq .Values.serviceType "ClusterIP" }}
+Minio can be accessed via port {{ .Values.servicePort }} on the following DNS name from within your cluster:
+{{ template "fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
+
+To access Minio from localhost, run the below commands:
+
+  1. export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "fullname" . }}" -o jsonpath="{.items[0].metadata.name}")
+
+  2. kubectl port-forward $POD_NAME 9000 --namespace {{ .Release.Namespace }}
+
+Read more about port forwarding here: http://kubernetes.io/docs/user-guide/kubectl/kubectl_port-forward/
+
+You can now access Minio server on http://localhost:9000. Follow the below steps to connect to Minio server with mc client:
+
+  1. Download the Minio mc client - https://docs.minio.io/docs/minio-client-quickstart-guide
+
+  2. mc config host add {{ template "fullname" . }}-local http://localhost:9000 {{ .Values.accessKey }} {{ .Values.secretKey }} S3v4
+
+  3. mc ls {{ template "fullname" . }}-local
+
+Alternately, you can use your browser or the Minio SDK to access the server - https://docs.minio.io/categories/17
+{{- end }}
+{{- if eq .Values.serviceType "LoadBalancer" }}
+Minio can be accessed via port {{ .Values.servicePort }} on an external IP address. Get the service external IP address by:
+kubectl get svc --namespace {{ .Release.Namespace }} -l app={{ template "fullname" . }}
+
+Note that the public IP may take a couple of minutes to be available.
+
+You can now access Minio server on http://<External-IP>:9000. Follow the below steps to connect to Minio server with mc client:
+
+  1. Download the Minio mc client - https://docs.minio.io/docs/minio-client-quickstart-guide
+
+  2. mc config host add {{ template "fullname" . }}-local http://<External-IP>:{{ .Values.servicePort }} {{ .Values.accessKey }} {{ .Values.secretKey }} S3v4
+
+  3. mc ls {{ template "fullname" . }}-local
+
+Alternately, you can use your browser or the Minio SDK to access the server - https://docs.minio.io/categories/17
+{{- end }}

--- a/incubator/tensorflow-inception/charts/minio/templates/_helpers.tpl
+++ b/incubator/tensorflow-inception/charts/minio/templates/_helpers.tpl
@@ -1,0 +1,16 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/incubator/tensorflow-inception/charts/minio/templates/minio_deployment.yaml
+++ b/incubator/tensorflow-inception/charts/minio/templates/minio_deployment.yaml
@@ -1,0 +1,76 @@
+{{- if eq .Values.mode "standalone" "shared" }}
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  {{- if eq .Values.mode "shared" }}
+  replicas: {{ .Values.replicas }}
+  {{- end }}
+  selector:
+    matchLabels:
+      app: {{ template "fullname" . }}
+  template:
+    metadata:
+      name: {{ template "fullname" . }}
+      labels:
+        app: {{ template "fullname" . }}
+        chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+        release: "{{ .Release.Name }}"
+        heritage: "{{ .Release.Service }}"
+    spec:
+      volumes:
+        - name: export
+        {{- if .Values.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ template "fullname" . }}
+        {{- else }}
+          emptyDir: {}
+        {{- end }}
+        - name: minio-server-config
+          configMap:
+            name: {{ template "fullname" . }}-config-cm
+        - name: minio-user
+          secret:
+            secretName: {{ template "fullname" . }}-user
+      containers:
+        - name: minio
+          image: {{ .Values.image }}:{{ .Values.imageTag }}
+          imagePullPolicy: {{ .Values.imagePullPolicy }}
+          command: ["minio"]
+          {{- if .Values.configPath }}
+          args: ["-C", "{{ .Values.configPath }}", "server", "{{ .Values.mountPath }}"]
+          {{- else }}
+          args: ["server", "{{ .Values.mountPath }}"]
+          {{- end }}
+          volumeMounts:
+            - name: export
+              mountPath: {{ .Values.mountPath }}
+            - name: minio-server-config
+              mountPath: {{ default "/root/.minio/" .Values.configPath | quote }}
+          ports:
+            - name: service
+              containerPort: 9000
+          env:
+            - name: MINIO_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "fullname" . }}-user
+                  key: accesskey
+            - name: MINIO_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "fullname" . }}-user
+                  key: secretkey
+          livenessProbe:
+            tcpSocket:
+              port: 9000
+            timeoutSeconds: 1
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+{{- end }}

--- a/incubator/tensorflow-inception/charts/minio/templates/minio_distributed_configmap.yaml
+++ b/incubator/tensorflow-inception/charts/minio/templates/minio_distributed_configmap.yaml
@@ -1,0 +1,23 @@
+{{- if eq .Values.mode "distributed" }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "fullname" . }}-cm
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+{{ $nodeCount := .Values.replicas | int }}
+data:
+  start.sh: |
+     #!/bin/sh
+     {{- if .Values.configPath }}
+     minio -C {{ .Values.configPath }} server \
+     {{- else }}
+     minio server \
+     {{- end }}
+     {{- range $i := until $nodeCount }}
+     http://{{ template "fullname" $ }}-{{$i}}.{{ template "fullname" $ }}.{{ $.Release.Namespace }}.svc.cluster.local{{ $.Values.mountPath }} \
+{{- end }}
+{{- end }}

--- a/incubator/tensorflow-inception/charts/minio/templates/minio_pvc.yaml
+++ b/incubator/tensorflow-inception/charts/minio/templates/minio_pvc.yaml
@@ -1,0 +1,24 @@
+{{- if eq .Values.mode "standalone" "shared" }}
+{{- if .Values.persistence.enabled }}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ template "fullname" . }}
+  annotations:
+{{- if .Values.persistence.storageClass }}
+    volume.beta.kubernetes.io/storage-class: {{ .Values.persistence.storageClass | quote }}
+{{- else }}
+    volume.alpha.kubernetes.io/storage-class: default
+{{- end }}
+spec:
+  accessModes:
+    {{- if eq .Values.mode "shared" }}
+    - ReadWriteMany
+    {{- else }}
+    - {{ .Values.persistence.accessMode | quote }}
+    {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size | quote }}
+{{- end }}
+{{- end }}

--- a/incubator/tensorflow-inception/charts/minio/templates/minio_secret.yaml
+++ b/incubator/tensorflow-inception/charts/minio/templates/minio_secret.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "fullname" . }}-user
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+type: Opaque
+data:
+  accesskey: {{ .Values.accessKey | b64enc }}
+  secretkey: {{ .Values.secretKey | b64enc }}

--- a/incubator/tensorflow-inception/charts/minio/templates/minio_statefulset.yaml
+++ b/incubator/tensorflow-inception/charts/minio/templates/minio_statefulset.yaml
@@ -1,0 +1,100 @@
+{{- if eq .Values.mode "distributed" }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  clusterIP: None
+  ports:
+    - name: service
+      port: 9000
+      targetPort: {{ .Values.servicePort }}
+      protocol: TCP
+  selector:
+    app: {{ template "fullname" . }}
+---
+apiVersion: apps/v1beta1
+kind: StatefulSet
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  serviceName: {{ template "fullname" . }}
+  replicas: {{ .Values.replicas }}
+  selector:
+    matchLabels:
+      app: {{ template "fullname" . }}
+  template:
+    metadata:
+      name: {{ template "fullname" . }}
+      labels:
+        app: {{ template "fullname" . }}
+        chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+        release: "{{ .Release.Name }}"
+        heritage: "{{ .Release.Service }}"
+    spec:
+      volumes:
+        - name: minio-user
+          secret:
+            secretName: {{ template "fullname" . }}-user
+        - name: minio-configmap
+          configMap:
+            name: {{ template "fullname" . }}-cm
+        - name: minio-server-config
+          configMap:
+            name: {{ template "fullname" . }}-config-cm
+      containers:
+        - name: minio
+          image: {{ .Values.image }}:{{ .Values.imageTag }}
+          imagePullPolicy: {{ .Values.imagePullPolicy }}
+          command:
+            - /bin/sh
+            - /go/bin/start.sh
+          volumeMounts:
+            - name: export
+              mountPath: {{ .Values.mountPath }}
+            - name: minio-server-config
+              mountPath: {{ default "/root/.minio/" .Values.configPath | quote }}
+            - name: minio-configmap
+              mountPath: /go/bin/start.sh
+              subPath: start.sh
+          ports:
+            - name: service
+              containerPort: 9000
+          env:
+            - name: MINIO_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "fullname" . }}-user
+                  key: accesskey
+            - name: MINIO_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "fullname" . }}-user
+                  key: secretkey
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+  volumeClaimTemplates:
+    - metadata:
+        name: export
+        annotations:
+          {{- if .Values.persistence.storageClass }}
+          volume.beta.kubernetes.io/storage-class: {{ .Values.persistence.storageClass }}
+          {{- else }}
+          volume.alpha.kubernetes.io/storage-class: default
+          {{- end }}
+      spec:
+        accessModes: [ {{ .Values.persistence.accessMode | quote }} ]
+        resources:
+          requests:
+            storage: {{ .Values.persistence.size }}
+  {{- end }}

--- a/incubator/tensorflow-inception/charts/minio/templates/minio_svc.yaml
+++ b/incubator/tensorflow-inception/charts/minio/templates/minio_svc.yaml
@@ -1,0 +1,21 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: {{ template "fullname" . }}-svc
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  type: {{ .Values.serviceType }}
+  {{- if eq .Values.serviceType "LoadBalancer" }}
+  loadBalancerIP: {{ default "" .Values.minioLoadBalancerIP }}
+  {{- end }}
+  selector:
+    app: {{ template "fullname" . }}
+  ports:
+    - name: service
+      port: 9000
+      targetPort: {{ .Values.servicePort }}
+      protocol: TCP

--- a/incubator/tensorflow-inception/charts/minio/templates/minioconfig_configmap.yaml
+++ b/incubator/tensorflow-inception/charts/minio/templates/minioconfig_configmap.yaml
@@ -1,0 +1,106 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "fullname" . }}-config-cm
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+data:
+  config.json: |-
+    {
+      "version": "13",
+      "credential": {
+        "accessKey": {{ .Values.accessKey | quote }},
+        "secretKey": {{ .Values.secretKey | quote }}
+      },
+      "region": "us-east-1",
+      "logger": {
+        "console": {
+          "enable": true,
+          "level": "fatal"
+        },
+        "file": {
+          "enable": false,
+          "fileName": "",
+          "level": ""
+        }
+      },
+      "notify": {
+        "amqp": {
+          "1": {
+            "enable": {{ .Values.minioConfig.aqmp.enable }},
+            "url": {{ .Values.minioConfig.aqmp.url | quote }},
+            "exchange": {{ .Values.minioConfig.aqmp.exchange | quote }},
+            "routingKey": {{ .Values.minioConfig.aqmp.routingKey | quote }},
+            "exchangeType": {{ .Values.minioConfig.aqmp.exchangeType | quote }},
+            "mandatory": {{ .Values.minioConfig.aqmp.mandatory }},
+            "immediate": {{ .Values.minioConfig.aqmp.immediate }},
+            "durable": {{ .Values.minioConfig.aqmp.durable }},
+            "internal": {{ .Values.minioConfig.aqmp.internal }},
+            "noWait": {{ .Values.minioConfig.aqmp.noWait }},
+            "autoDeleted": {{ .Values.minioConfig.aqmp.autoDeleted }}
+          }
+        },
+        "nats": {
+          "1": {
+            "enable": {{ .Values.minioConfig.nats.enable }},
+            "address": {{ .Values.minioConfig.nats.address | quote }},
+            "subject": {{ .Values.minioConfig.nats.subject | quote }},
+            "username": {{ .Values.minioConfig.nats.username | quote }},
+            "password": {{ .Values.minioConfig.nats.password | quote }},
+            "token": {{ .Values.minioConfig.nats.token | quote }},
+            "secure": {{ .Values.minioConfig.nats.secure }},
+            "pingInterval": {{ .Values.minioConfig.nats.pingInterval | int64 }},
+            "streaming": {
+              "enable": {{ .Values.minioConfig.nats.enableStreaming }},
+              "clusterID": {{ .Values.minioConfig.nats.clusterID | quote }},
+              "clientID": {{ .Values.minioConfig.nats.clientID | quote }},
+              "async": {{ .Values.minioConfig.nats.async }},
+              "maxPubAcksInflight": {{ .Values.minioConfig.nats.maxPubAcksInflight | int }}
+            }
+          }
+        },
+        "elasticsearch": {
+          "1": {
+            "enable": {{ .Values.minioConfig.elasticsearch.enable }},
+            "url": {{ .Values.minioConfig.elasticsearch.url | quote }},
+            "index": {{ .Values.minioConfig.elasticsearch.index | quote }}
+          }
+        },
+        "redis": {
+          "1": {
+            "enable": {{ .Values.minioConfig.redis.enable }},
+            "address": {{ .Values.minioConfig.redis.address | quote }},
+            "password": {{ .Values.minioConfig.redis.password | quote }},
+            "key": {{ .Values.minioConfig.redis.key | quote }}
+          }
+        },
+        "postgresql": {
+          "1": {
+            "enable": {{ .Values.minioConfig.postgresql.enable }},
+            "connectionString": {{ .Values.minioConfig.postgresql.connectionString | quote }},
+            "table": {{ .Values.minioConfig.postgresql.table | quote }},
+            "host": {{ .Values.minioConfig.postgresql.host | quote }},
+            "port": {{ .Values.minioConfig.postgresql.port | quote }},
+            "user": {{ .Values.minioConfig.postgresql.user | quote }},
+            "password": {{ .Values.minioConfig.postgresql.password | quote }},
+            "database": {{ .Values.minioConfig.postgresql.database | quote }}
+          }
+        },
+        "kafka": {
+          "1": {
+            "enable": {{ .Values.minioConfig.kafka.enable }},
+            "brokers": {{ .Values.minioConfig.kafka.brokers }},
+            "topic": {{ .Values.minioConfig.kafka.topic | quote }}
+          }
+        },
+        "webhook": {
+          "1": {
+            "enable": {{ .Values.minioConfig.webhook.enable }},
+            "endpoint": {{ .Values.minioConfig.webhook.endpoint | quote }}
+          }
+        }
+      }
+    }

--- a/incubator/tensorflow-inception/charts/minio/values.yaml
+++ b/incubator/tensorflow-inception/charts/minio/values.yaml
@@ -1,0 +1,107 @@
+## Set default image, imageTag, and imagePullPolicy. mode is used to indicate the
+## minio server mode, i.e. standalone or distributed.
+## Distributed Minio ref: https://docs.minio.io/docs/distributed-minio-quickstart-guide
+##
+image: "minio/minio"
+imageTag: "RELEASE.2017-02-16T01-47-30Z"
+imagePullPolicy: "Always"
+mode: "standalone"
+
+## Set default accesskey, secretkey, Minio config file path, volume mount path and
+## number of nodes (only used for Minio distributed mode)
+## Distributed Minio ref: https://docs.minio.io/docs/distributed-minio-quickstart-guide
+##
+accessKey: "foobar"
+secretKey: "foobarfoo"
+configPath: ""
+mountPath: "/export"
+replicas: 4
+
+## loadBalancerIP for the Minio Service (optional, cloud specific)
+## ref: http://kubernetes.io/docs/user-guide/services/#type-loadbalancer
+##
+# minioLoadBalancerIP:
+
+## Enable persistence using Persistent Volume Claims
+## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
+##
+persistence:
+  enabled: true
+
+  ## If defined, volume.beta.kubernetes.io/storage-class: <storageClass>
+  ## Default: volume.alpha.kubernetes.io/storage-class: default
+  ##
+  # storageClass: <storageClass>
+  accessMode: ReadWriteOnce
+  size: 10Gi
+
+## Expose the Minio service to be accessed from outside the cluster (LoadBalancer service).
+## or access it from within the cluster (ClusterIP service). Set the service type and the port to serve it.
+## ref: http://kubernetes.io/docs/user-guide/services/
+##
+serviceType: LoadBalancer
+servicePort: 9000
+
+## Configure resource requests and limits
+## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+##
+resources:
+  requests:
+    memory: 256Mi
+    cpu: 250m
+
+## Below settings can be used to setup event notifications as explained here.
+## https://docs.minio.io/docs/minio-bucket-notification-guide
+##
+minioConfig:
+  aqmp:
+    enable: false
+    url: ""
+    exchange: ""
+    routingKey: ""
+    exchangeType: ""
+    mandatory: false
+    immediate: false
+    durable: false
+    internal: false
+    noWait: false
+    autoDeleted: false
+  nats:
+    enable: false
+    address: ""
+    subject: ""
+    username: ""
+    password: ""
+    token: ""
+    secure: false
+    pingInterval: 0
+    enableStreaming: false
+    clusterID: ""
+    clientID: ""
+    async: false
+    maxPubAcksInflight: 0
+  elasticsearch:
+    enable: false
+    url: ""
+    index: ""
+  redis:
+    enable: false
+    address: ""
+    password: ""
+    key: ""
+  postgresql:
+    enable: false
+    connectionString: ""
+    table: ""
+    host: ""
+    port: ""
+    user: ""
+    password: ""
+    database: ""
+  kafka:
+    enable: true
+    brokers: "[\"kafka.kubeless:9092\"]"
+    topic: "s3"
+  webhook:
+    enable: false
+    endpoint: ""

--- a/incubator/tensorflow-inception/charts/tensorflow-inception/Chart.yaml
+++ b/incubator/tensorflow-inception/charts/tensorflow-inception/Chart.yaml
@@ -1,0 +1,19 @@
+name: tensorflow-serving
+version: 0.0.1
+app_version: 0.5.1
+description: Open-source software library for serving machine learning models
+keywords:
+- tensorflow
+- serving
+- inception
+- machine
+- learning
+- library
+home: https://tensorflow.github.io/serving/
+sources:
+- https://github.com/bitnami/tensorflow-serving
+- https://github.com/bitnami/tensorflow-serving-client
+maintainers:
+- email: containers@bitnami.com
+  name: Bitnami
+engine: gotpl

--- a/incubator/tensorflow-inception/charts/tensorflow-inception/README.md
+++ b/incubator/tensorflow-inception/charts/tensorflow-inception/README.md
@@ -1,0 +1,84 @@
+# TensorFlow Serving Inception v3
+
+TensorFlow Serving is an open-source software library for serving machine learning models. This chart will specifically serve the Inception v3 model with already trained data.
+
+## TL;DR;
+
+```console
+$ helm install incubator/tensorflow-inception
+```
+
+## Introduction
+
+This chart bootstraps a TensorFlow Serving Inception v3 pod on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+
+## Prerequisites
+
+- Kubernetes 1.4+ with Beta APIs enabled
+- PV provisioner support in the underlying infrastructure
+
+## Get this chart
+
+Download the latest release of the chart from the [releases](../../../releases) page.
+
+Alternatively, clone the repo if you wish to use the development snapshot:
+
+```console
+$ git clone https://github.com/bitnami/tensorflow.git
+```
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```console
+$ helm install --name my-release incubator/tensorflow-inception
+```
+
+The command deploys Tensorflow Serving Inception v3 model on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
+
+> **Tip**: List all releases using `helm list`
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-release` deployment:
+
+```console
+$ helm delete my-release
+```
+You can check your releases with:
+
+```console
+$ helm list
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Configuration
+
+The following tables lists the configurable parameters of the TensorFlow Inception chart and their default values.
+
+| Parameter                       | Description                         | Default                                                    |
+| ------------------------------- | -------------------------------     | ---------------------------------------------------------- |
+| `server.image`                  | Tensorflow server image             | `bitnami/tensorflow-serving:{VERSION}`                     |
+| `server.port`                   | Tensorflow server port              | `9000`                                                     |
+| `client.image`                  | Tensorflow client image             | `bitnami/tensorflow-inception:{VERSION}`                   |
+| `imagePullPolicy`               | Image pull policy                   | `Always` if `image` tag is `latest`, else `IfNotPresent`   |
+| `persistence.enabled`           | Use a PVC to persist data           | `true`                                                     |
+| `persistence.storageClass`      | Storage class of backing PVC        | `nil` (uses alpha storage class annotation)                |
+| `persistence.accessMode`        | Use volume as ReadOnly or ReadWrite | `ReadWriteOnce`                                            |
+| `persistence.size`              | Size of data volume                 | `500Mi`                                                    |
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
+
+```console
+$ helm install --name my-release incubator/tensorflow-inception --set imagePullPolicy=Always
+```
+
+Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
+
+```console
+$ helm install --name my-release -f values.yaml incubator/tensorflow-inception
+```
+
+> **Tip**: You can use the default [values.yaml](values.yaml)

--- a/incubator/tensorflow-inception/charts/tensorflow-inception/templates/NOTES.txt
+++ b/incubator/tensorflow-inception/charts/tensorflow-inception/templates/NOTES.txt
@@ -1,0 +1,19 @@
+1. Get the TensorFlow Serving URL by running:
+
+  {{- if contains "NodePort" .Values.serviceType }}
+
+  export APP_HOST=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  export APP_PORT=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "fullname" . }} -o jsonpath="{.spec.ports[0].nodePort}")
+
+  {{- else if contains "LoadBalancer" .Values.serviceType }}
+
+  NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+        Watch the status with: 'kubectl get svc --namespace {{ .Release.Namespace }} -w {{ template "fullname" . }}'
+
+  export APP_HOST=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  export APP_PORT=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "fullname" . }} -o jsonpath="{.spec.ports[0].port}")
+  {{- end }}
+
+2. Test the server with a sample image.
+
+  docker run --rm -it bitnami/tensorflow-inception inception_client --server=$APP_HOST:$APP_PORT --image=/opt/bitnami/tensorflow-inception/tensorflow/tensorflow/contrib/ios_examples/benchmark/data/grace_hopper.jpg

--- a/incubator/tensorflow-inception/charts/tensorflow-inception/templates/_helpers.tpl
+++ b/incubator/tensorflow-inception/charts/tensorflow-inception/templates/_helpers.tpl
@@ -1,0 +1,16 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/incubator/tensorflow-inception/charts/tensorflow-inception/templates/deployment.yaml
+++ b/incubator/tensorflow-inception/charts/tensorflow-inception/templates/deployment.yaml
@@ -1,0 +1,40 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: {{ template "fullname" . }}
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: tensorflow-serving
+    spec:
+      containers:
+      - name: {{ template "fullname" . }}
+        image: {{ .Values.server.image }}
+        readinessProbe:
+          tcpSocket:
+            port: {{ .Values.server.port }}
+          timeoutSeconds: 5
+        livenessProbe:
+          tcpSocket:
+            port: {{ .Values.server.port }}
+          initialDelaySeconds: 30
+          timeoutSeconds: 5
+          failureThreshold: 6
+        volumeMounts:
+        - name: seed
+          mountPath: "/bitnami/model-data"
+        - name: data
+          mountPath: /bitnami/tensorflow-serving
+      volumes:
+      - name: seed
+        persistentVolumeClaim:
+          claimName: {{ template "fullname" . }}-seed-inception
+      - name: data
+      {{- if .Values.persistence.enabled }}
+        persistentVolumeClaim:
+          claimName: {{ template "fullname" . }}
+      {{- else }}
+        emptyDir: {}
+      {{- end -}}

--- a/incubator/tensorflow-inception/charts/tensorflow-inception/templates/inception-job.yaml
+++ b/incubator/tensorflow-inception/charts/tensorflow-inception/templates/inception-job.yaml
@@ -1,0 +1,26 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ template "fullname" . }}-seed-inception
+spec:
+  template:
+    metadata:
+      name: seed-inception
+    spec:
+      containers:
+      - name: seed
+        image: {{ .Values.client.image }}
+        command: ["/bin/sh"]
+        args: ["-c", "curl -o /seed/inception-v3-2016-03-01.tar.gz http://download.tensorflow.org/models/image/imagenet/inception-v3-2016-03-01.tar.gz && \
+                      cd /seed/ && tar -xzf inception-v3-2016-03-01.tar.gz && \
+                      rm inception-v3-2016-03-01.tar.gz && \
+                      inception_saved_model --checkpoint_dir=/seed/inception-v3 --output_dir=/seed/ && \
+                      rm -rf inception-v3"]
+        volumeMounts:
+        - name: seed
+          mountPath: /seed
+      restartPolicy: Never
+      volumes:
+      - name: seed
+        persistentVolumeClaim:
+          claimName: {{ template "fullname" . }}-seed-inception

--- a/incubator/tensorflow-inception/charts/tensorflow-inception/templates/inception-pvc.yaml
+++ b/incubator/tensorflow-inception/charts/tensorflow-inception/templates/inception-pvc.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ template "fullname" . }}-seed-inception
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 500Mi

--- a/incubator/tensorflow-inception/charts/tensorflow-inception/templates/pvc.yaml
+++ b/incubator/tensorflow-inception/charts/tensorflow-inception/templates/pvc.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.persistence.enabled }}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ template "fullname" . }}
+  annotations:
+  {{- if .Values.persistence.storageClass }}
+    volume.beta.kubernetes.io/storage-class: {{ .Values.persistence.storageClass | quote }}
+  {{- else }}
+    volume.alpha.kubernetes.io/storage-class: default
+  {{- end }}
+spec:
+  accessModes:
+    - {{ .Values.persistence.accessMode | quote }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size | quote }}
+{{- end }}

--- a/incubator/tensorflow-inception/charts/tensorflow-inception/templates/svc.yaml
+++ b/incubator/tensorflow-inception/charts/tensorflow-inception/templates/svc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "fullname" . }}
+spec:
+  type: {{ .Values.serviceType }}
+  ports:
+  - port: {{ .Values.server.port }}
+    protocol: TCP
+  selector:
+    app: tensorflow-serving

--- a/incubator/tensorflow-inception/charts/tensorflow-inception/values.yaml
+++ b/incubator/tensorflow-inception/charts/tensorflow-inception/values.yaml
@@ -1,0 +1,35 @@
+## TensorFlow Serving server image version
+## ref: https://hub.docker.com/r/bitnami/tensorflow-serving/tags/
+##
+server:
+  image: tompizmor/tensorflow-serving:latest
+  port: 9000
+
+## TensorFlow Serving Client image version
+## ref: https://hub.docker.com/r/bitnami/tensorflow-serving-client/tags/
+##
+client:
+  image: tompizmor/tensorflow-serving-client:latest
+
+## Specify a imagePullPolicy
+## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
+## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
+##
+# imagePullPolicy:
+
+## Enable persistence using Persistent Volume Claims
+## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
+##
+persistence:
+  enabled: true
+  ## If defined, volume.beta.kubernetes.io/storage-class: <storageClass>
+  ## Default: volume.alpha.kubernetes.io/storage-class: default
+  ##
+  # storageClass:
+  accessMode: ReadWriteOnce
+  size: 500Mi
+
+## Kubernetes configuration
+## For minikube, set this to NodePort, elsewhere use LoadBalancer
+##
+serviceType: LoadBalancer

--- a/incubator/tensorflow-inception/requirements.txt
+++ b/incubator/tensorflow-inception/requirements.txt
@@ -1,0 +1,4 @@
+slackclient
+kubernetes
+minio
+websocket-client==0.40.0


### PR DESCRIPTION
I've created a kubeless pipeline for image recognition using the tensorflow-inception model.
When you drop an image on a monitored Minio bucket, it will be analyzed using the tensorflow-inception model  and the result will be send to a slack channel.