### PR TITLE
Add minio-slack example

### DIFF
--- a/charts/minio/values.yaml
+++ b/charts/minio/values.yaml
@@ -100,7 +100,7 @@ minioConfig:
     database: ""
   kafka:
     enable: true
-    brokers: "kafka.kubeless"
+    brokers: "[\"kafka.kubeless:9092\"]"
     topic: "s3"
   webhook:
     enable: false

--- a/incubator/minio-slack/README.md
+++ b/incubator/minio-slack/README.md
@@ -1,0 +1,94 @@
+# Send messages on objects upload to a bucket
+
+Make sure `minikube` and `kubeless` are installed. See the respective installation guides:
+* [Minikube](https://github.com/kubernetes/minikube#installation)
+* [Kubeless](https://github.com/kubeless/kubeless/blob/master/README.md#usage)
+
+
+## Prepare the environment
+
+This example uses the Minio S3 clone to show case a kubeless pubsub function. Minio is configured to send notifications to Kafka, a function consumes those events and performs actions.
+
+### Create Minio and Slack kubernetes secrets
+
+In order to access to the minio object storage and to send messages to a slack channel you need
+
+The access_key and secret_key for minio are configured in the helm chart template. You can edit the file values.yml and specify the keys you want to use. This secret will be deployed to kubernetes while deploying Minio so no further action is required.
+
+For the slack secret you need to obtain your slack token from [this page](https://api.slack.com/custom-integrations/legacy-tokens) and then deploy a secret to kubernetes with this command:
+
+```bash
+kubectl create secret generic slack --from-literal=token=YOUR_SLACK_TOKEN
+```
+
+### Deploy Minio via Helm
+
+```bash
+helm repo add
+helm install --name minio ./minio --set serviceType=NodePort
+```
+
+### Configure Minio
+
+
+You will need the Minio [client](https://github.com/minio/mc) `mc`:
+
+```bash
+brew install minio-mc
+```
+
+The following are Minio specific, it assumes your are using minikube on `192.168.99.100` and the minio service is running on port `32751`
+
+```bash
+mc config host add localminio http://192.168.99.100:32751 foobar foobarfoo
+```
+
+Create a foobar bucket:
+
+```bash
+$ mc mb localminio/foobar
+```
+
+Turn on events for a `foobar` bucket:
+
+```bash
+mc events add localminio/foobar arn:minio:sqs:us-east-1:1:kafka --events put
+```
+
+Check bucket
+
+```bash
+mc ls localminio/foobar
+```
+
+
+## Deploy the function with kubeless
+
+### 1. Deploy
+
+In order to deploy the function run the following command:
+
+```bash
+$ kubeless function deploy minio-slack --from-file minio-slack.py --handler minio-slack.handler --runtime python2.7 --trigger-topic s3 --dependencies requirements.txt
+```
+
+You can list the function with `kubeless function ls` and you should see the following:
+
+```
+$ kubeless function ls
++-------------+-----------+---------------------+-----------+--------+-------+-------------------------------+
+|    NAME     | NAMESPACE |       HANDLER       |  RUNTIME  |  TYPE  | TOPIC |         DEPENDENCIES          |
++-------------+-----------+---------------------+-----------+--------+-------+-------------------------------+
+| minio-slack | default   | minio-slack.handler | python2.7 | PubSub | s3    | slackclient kubernetes minio  |
++-------------+-----------+---------------------+-----------+--------+-------+-------------------------------+
+```
+
+### 2. Invoke
+
+To trigger the function you only need to upload a file to the `foobar` bucket using the Minio web interface of the minio client.
+
+Login to the Minio UI and upload some file to the `foobar` bucket.
+
+```bash
+minikube service minio-minio-svc
+```

--- a/incubator/minio-slack/minio-slack.py
+++ b/incubator/minio-slack/minio-slack.py
@@ -1,0 +1,49 @@
+import json
+import base64
+import tempfile
+
+#pip install slackclient
+from slackclient import SlackClient
+
+#pip install kubernetes
+from kubernetes import client, config
+
+# pip install minio
+from minio import Minio
+from minio.error import ResponseError
+
+config.load_incluster_config()
+
+v1=client.CoreV1Api()
+
+#Get minio and slack secrets
+for secrets in v1.list_secret_for_all_namespaces().items:
+    if secrets.metadata.name == 'minio-minio-user':
+        access_key = base64.b64decode(secrets.data['accesskey'])
+        secret_key = base64.b64decode(secrets.data['secretkey'])
+    if secrets.metadata.name == 'slack':
+        token = base64.b64decode(secrets.data['token'])
+
+
+# Replace the DNS below with the minio service name (helm release name -svc)
+client = Minio('minio-minio-svc:9000',
+                  access_key=access_key,
+                  secret_key=secret_key,
+                  secure=False)
+
+sc = SlackClient(token)
+
+def handler(context):
+    if context['EventType'] == "s3:ObjectCreated:Put":
+        bucket = context['Key'].split('/')[0]
+        filename = context['Key'].split('/')[1]
+
+        msg = "An object called %s was uploaded to bucket %s" % (filename,bucket)
+
+        sc.api_call(
+                    "chat.postMessage",
+                    channel="#bot",
+                    text=msg
+                   )
+
+    return "Notification sent to SLACK"

--- a/incubator/minio-slack/requirements.txt
+++ b/incubator/minio-slack/requirements.txt
@@ -1,0 +1,3 @@
+slackclient
+kubernetes
+minio


### PR DESCRIPTION
Add new example: Upload a file to a Minio bucket and get a notification in slack.

This example does not include `serverless.yml` or `package.json` as pub/sub triggered functions does not work yet with the serverless-kubeless plugin.