### PR TITLE
Add kubeless-functions-charts commands to README

### DIFF
--- a/incubator/minio-slack/README.md
+++ b/incubator/minio-slack/README.md
@@ -24,8 +24,8 @@ kubectl create secret generic slack --from-literal=token=YOUR_SLACK_TOKEN
 ### Deploy Minio via Helm
 
 ```bash
-helm repo add
-helm install --name minio ./minio --set serviceType=NodePort
+helm repo add kubeless-functions-charts https://kubeless-functions-charts.storage.googleapis.com
+helm install --name minio kubeless-functions-charts/minio --set serviceType=NodePort
 ```
 
 ### Configure Minio


### PR DESCRIPTION
I created the helm repo to store the charts of the kubeless/functions repo and updated the README for the minio-slack example