### PR TITLE
Increase flexibility by allowing for env vars: 

### DIFF
--- a/charts/debezium-connect/templates/deployment.yaml
+++ b/charts/debezium-connect/templates/deployment.yaml
@@ -27,6 +27,10 @@ spec:
           value: {{ .Values.config.offsetStorageTopic }}
         - name: BOOTSTRAP_SERVERS
           value: {{ .Values.config.bootstrapServers }}
+        {{- range $key, $value := $.Values.env }}
+        - name: {{ $key }}
+          value: {{ $value | quote }}
+        {{- end }}
         ports:
         - containerPort: {{ .Values.service.internalPort }}
         resources:


### PR DESCRIPTION
Example possibilities:
`helm install more-customized \
--set env.CONNECT_KEY_CONVERTER_SCHEMA_REGISTRY_URL=http://$namespace-kafka-cp-schema-registry:8081 \
  --set env.CONNECT_VALUE_CONVERTER_SCHEMA_REGISTRY_URL=http://$namespace-kafka-cp-schema-registry:8081 \
  --set env.INTERNAL_KEY_CONVERTER=org.apache.kafka.connect.json.JsonConverter \
  --set env.INTERNAL_VALUE_CONVERTER=org.apache.kafka.connect.json.JsonConverter \
  --set env.CONFIG_STORAGE_TOPIC=docker-connect-configs \
  --set env.GROUP_ID=compose-connect-group \
  --set env.CONFIG_STORAGE_REPLICATION_FACTOR=1 \
  --set env.OFFSET_FLUSH_INTERVAL_MS=10000 \
  --set env.OFFSET_STORAGE_TOPIC=docker-connect-offsets \
  --set env.OFFSET_STORAGE_REPLICATION_FACTOR=1 \
  --set env.STATUS_STORAGE_TOPIC=docker-connect-status \
  --set env.STATUS_STORAGE_REPLICATION_FACTOR=1 \
  --set env.KEY_CONVERTER=io.confluent.connect.avro.AvroConverter \
  --set env.VALUE_CONVERTER=io.confluent.connect.avro.AvroConverter \
  --set env.INTERNAL_KEY_CONVERTER=org.apache.kafka.connect.json.JsonConverter \
  --set env.INTERNAL_VALUE_CONVERTER=org.apache.kafka.connect.json.JsonConverter \
  --set env.CLASSPATH=/usr/share/java/monitoring-interceptors/monitoring-interceptors-5.0.0-beta30.jar \
  --set env.PRODUCER_INTERCEPTOR_CLASSES="io.confluent.monitoring.clients.interceptor.MonitoringProducerInterceptor" \
  --set env.CONSUMER_INTERCEPTOR_CLASSES="io.confluent.monitoring.clients.interceptor.MonitoringConsumerInterceptor" \
  --set env.PLUGIN_PATH=/usr/share/java $deb_charts/charts/debezium-connect
  `